### PR TITLE
Multiple fixes; Better efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ However it will not match
  * :tag
  * [[:alpha:]]:tag
 
-By default, both are set to \*\*None\*\* which is the same as the blank string.  If you want to keep ALL images, containers or volumes then you should use \*\*All\*\* to match all items. Do not use a bare **\*** as this will be taken as a filename match. Note that with KEEP_VOLUMES_NAMED, **All** will keep all named volumes, but still delete the unnamed ones.
+By default, both are set to \*\*None\*\* which is the same as the blank string.  If you want to keep ALL images, containers or volumes then you should use \*\*All\*\* to match all items. Do not use a bare **\*** as this will be taken as a filename match. Note that with KEEP_VOLUMES_NAMED, \*\*All\*\* will keep all named volumes, but still delete the unnamed ones.
 
 ## Deployment
 The image uses the Docker client to to list and remove containers and images. For this reason the Docker client and socket is mapped into the container.


### PR DESCRIPTION
I'd like some feedback on this, but I believe I have maintained the integrity of the script.

I have done the following:

1. Reordered execution to remove redundancy and add safety
While reading the script, I noticed that the unused images are being processed "again" (as the comments indicate), but the work being done the first time is never consumed.  I thought about it potentially being there as a purposeful delay but could not come up with a reason.
By removing the "-v" from the "docker rm" commands and moving the unused volume processing to the end, this allows for the careful removal of volumes (contrary to the README.md).  I'm not sure I've thought of all use cases, but I believe I have solved a few.

2. Added skip for DELAY_TIME if we start with no unstarted created containers.
I didn't see a benefit provided by waiting for a recheck on created containers if none existed in the first place.  My understanding is the purpose was only to monitor if created containers eventually started.

3. Simplified some commands
There were many instances where tail, head, and grep were being used for something "--format" could solve simply and without spinning additional processes.  This also shortened the command altogether for easier readability.

4. Fixed some inconsistencies
I noticed some commands weren't being executed the same globally in the script and some echos didn't have double-quotes.

5. Moved IFS outside loop since the effect was the same.  Not even sure it's still needed
Originally, IFS=... was inside the loop after the volume processing (which used to be first).  The problem I saw here is that upon second execution, IFS would already be set when entering the volume processing.  I believe that the use of IFS was originally in place for the older /docker-cleanup-volumes.sh, which is no longer used, but I didn't want to remove it in the event there was an edge case.


You will notice some TODO comments.  I plan on investigating the ability to add labels as a method of filtering containers for cleanup.  Specifically, in the case of start_once containers under Rancher, we ought not delete these or Rancher will spin them back up negating their original start_once configuration.